### PR TITLE
PLANNER-2250 Disable flaky tests

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhaseTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.optaplanner.core.api.solver.Solver;
@@ -165,6 +166,7 @@ public class DefaultPartitionedSearchPhaseTest {
         assertThat(solutionFuture.get()).isNotNull();
     }
 
+    @Disabled("PLANNER-2249")
     @Test
     @Timeout(5)
     public void shutdownMainThreadAbruptly() throws InterruptedException {

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingDaemonTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingDaemonTest.java
@@ -24,6 +24,7 @@ import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.optaplanner.core.api.solver.Solver;
@@ -50,6 +51,7 @@ public class CloudBalancingDaemonTest extends LoggingTest {
     private volatile Throwable solverThreadException = null;
     private volatile CloudBalance currentBestSolution = null;
 
+    @Disabled("PLANNER-2249")
     @Test
     @Timeout(600)
     public void daemon() throws InterruptedException {

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingDaemonTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/cloudbalancing/app/CloudBalancingDaemonTest.java
@@ -27,7 +27,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.Disabled;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.api.solver.event.BestSolutionChangedEvent;


### PR DESCRIPTION
Tests identified as flaky:

DefaultPartitionedSearchPhaseTest.shutdownMainThreadAbruptly
CloudBalancingDaemonTest.daemon

These tests have failed sporadically in the past and need to be reviewed.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
